### PR TITLE
run.sh fixes

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-java --module-path devday-service\target\devday-service-1.0-SNAPSHOT.jar:devday\target\devday-1.0-SNAPSHOT.jar:devday-workshop-service\target\devday-workshop-service-1.0-SNAPSHOT.jar:devday-talk-service\target\devday-talk-service-1.0-SNAPSHOT.jar -m de.consol.devday/de.consol.devday.Devday
+$JDK_HOME/bin/java --module-path devday-service/target/devday-service-1.0-SNAPSHOT.jar:devday/target/devday-1.0-SNAPSHOT.jar:devday-workshop-service/target/devday-workshop-service-1.0-SNAPSHOT.jar:devday-talk-service/target/devday-talk-service-1.0-SNAPSHOT.jar -m de.consol.devday/de.consol.devday.Devday


### PR DESCRIPTION
Fixed path of modules and defined environment-based java binary on run.sh script

Before the adjustments, there always was displayed the following error:

`Error occurred during initialization of boot layer
java.lang.module.FindException: Module de.consol.devday not found`